### PR TITLE
MaJ gestion interface

### DIFF
--- a/StimulusFrontEnd/Components/TheorieComponents/Exercice.razor
+++ b/StimulusFrontEnd/Components/TheorieComponents/Exercice.razor
@@ -179,14 +179,14 @@
         }
 
         /*
-        if (FichierCode.Count == 0)
-        {
+            if (FichierCode.Count == 0)
+            {
             var fichiers = await ApiClient.PageExerciceGETAsync(ExerciceModel.Id);
             List<FichierSource>? fichiersSource = JsonConvert.DeserializeObject<List<FichierSource>>(fichiers.FichierSource);
             foreach (FichierSource fichier in fichiersSource)
-            {
+                {
                 FichierCode.Add(new Fichier(-(FichierCode.Count + 1), fichier.Nom, fichier.Contenu));
-            }
+        }
         }
         */
 
@@ -263,10 +263,11 @@
             }
         }
 
+        string texte = await GetCode();
         fichiers.Add(new
         {
             Nom = "main.py",
-            Contenu = await GetCode()
+            Contenu = texte.Replace("\"", "\'")
         });        
 
         jsonString = JsonConvert.SerializeObject(fichiers);
@@ -374,9 +375,9 @@
     /// </summary>
     private async void AddPage()
     {
-        var nomFichier = await JS.InvokeAsync<string>("PromptFunction.promptFunc", null);
+        string nomFichier = await JS.InvokeAsync<string>("PromptFunction.promptFunc", null);
 
-        if (nomFichier == "")
+        if (String.IsNullOrWhiteSpace(nomFichier))
         {
             Result = "Nom de fichier invalide";
         }
@@ -389,10 +390,10 @@
 
             FichierCode.Add(new Fichier()
                 {
-                    Contenu = "",
+                    Contenu = "print('Hello World !')",
                     Nom = nomFichier,
                     Id = -(FichierCode.Count + 1),
-                    Css = FocusedTab
+                    Css = FocusedTab                    
                 });
         }
 

--- a/StimulusFrontEnd/Components/TheorieComponents/Exercice.razor
+++ b/StimulusFrontEnd/Components/TheorieComponents/Exercice.razor
@@ -75,7 +75,17 @@
         return code;
     }
 
-    private async Task SetCode(string code = "print('Code par défaut')")
+    private const string texteDefaut = "texte = \"\"\n" +
+                                "onglets = False\n\n" +
+                                "# Si il y a des onglets\n" +
+                                "if (onglets == True):\n" +
+                                "\ttexte = \"Choisissez un onglet pour commencer a coder !\"\n" +
+                                "# Si il n'y a pas d'onglets\n" +
+                                "elif (onglets == False):\n" +
+                                "\ttexte = \"Creez un onglet avec le bouton '+' puis commencez a coder !\"\n" +
+                                "print (texte)";
+
+    private async Task SetCode(string code = texteDefaut)
     {
         if (_editor != null)
             await _editor.SetValue(code);
@@ -88,7 +98,7 @@
                 AutomaticLayout = true,
                 Language = "python",
                 Theme = "vs-dark",
-                Value = FichierCode.FirstOrDefault().Contenu
+                Value = texteDefaut
             };
     }
 
@@ -168,6 +178,7 @@
                 });
         }
 
+        /*
         if (FichierCode.Count == 0)
         {
             var fichiers = await ApiClient.PageExerciceGETAsync(ExerciceModel.Id);
@@ -177,6 +188,7 @@
                 FichierCode.Add(new Fichier(-(FichierCode.Count + 1), fichier.Nom, fichier.Contenu));
             }
         }
+        */
 
         //FichierCode[0].Css = FocusedTab;
 
@@ -242,18 +254,21 @@
         Result = "Interprétation du code...";
         Console.WriteLine("Running python code...");
         StateHasChanged();
-        foreach (Fichier f in FichierCode)
+
+        foreach (var fichier in FichierCode)
         {
-            if (f.Css != "hidden")
+            if (fichier.Css != "hidden")
             {
-                f.Contenu = await GetCode();
-                fichiers.Add(new
-                {
-                    Nom = f.Nom,
-                    Contenu = f.Contenu.Replace("\"", "\'")
-                });
+                await ChangeTab(fichier.Id);
             }
         }
+
+        fichiers.Add(new
+        {
+            Nom = "main.py",
+            Contenu = await GetCode()
+        });        
+
         jsonString = JsonConvert.SerializeObject(fichiers);
 
         //Voir pour le mettre en post


### PR DESCRIPTION
# Description
Modification de l'interface code-interpréteur:
- Peut interpréter le code entré, même si il n'est dans aucun onglet
- Suppression de l'onglet par défaut quand pas d'onglet existant (mis en commentaire on sais jamais)
- Pas besoin de sauvegarder le code dans un fichier "main.py" pour autoriser l'execution
- Impossible d'avoir des noms de fichier nuls

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Updating existing code

# How Has This Been Tested?
- [x] Entrer du code dans l'interpréteur sans onglets
- [x] Entrer du code dans l'interpréteur avec onglets mais le code "flottant" -> Ne pas cliquer d'onglet quand la page apparait la première fois
- [x] Sauvegarder le code dans un onglet "Exercice 1" et ensuite executé
- [x] Ajouter des fichiers avec un nom nul
