### PR TITLE
Suppression ajout admin

### DIFF
--- a/StimulusAPI/Controllers/LoginController.cs
+++ b/StimulusAPI/Controllers/LoginController.cs
@@ -252,25 +252,6 @@ namespace StimulusAPI.Controllers
                     }
                     break;
                 case "Administrateur":
-                    await using (SqlConnection connection = new SqlConnection(connectionString))
-                    {
-                        try
-                        {
-                            connection.Open();
-                            string insertQuery = "INSERT INTO dbo.administrateur (nom, prenom, mot_de_passe) VALUES (@Valeur1, @Valeur2, @Valeur3)";
-                            using (SqlCommand command = new SqlCommand(insertQuery, connection))
-                            {
-                                command.Parameters.AddWithValue("@Valeur1", user.Nom);
-                                command.Parameters.AddWithValue("@Valeur2", user.Prenom);
-                                command.Parameters.AddWithValue("@Valeur3", user.Password);
-                                command.ExecuteNonQuery();
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            return StatusCode(StatusCodes.Status500InternalServerError, new Reponse { Status = "Error", Message = "Erreur inattendue liée à la base de données, contactez un administrateur" });
-                        }
-                    }
                     break;
             }
             return Ok(new Reponse { Status = "200 Ok", Message = "200 Ok" });


### PR DESCRIPTION
# Description

Suppression de la structure permettant d'ajouter un administrateur dans la table administrateur, suite a la suppression de cette dernière

Toujours présent dans le switch pour éviter de générer une erreur
