### PR TITLE
Fix mineur bouton sauvegarder et exécuter

### DIFF
--- a/StimulusFrontEnd/Components/TheorieComponents/Exercice.razor
+++ b/StimulusFrontEnd/Components/TheorieComponents/Exercice.razor
@@ -39,7 +39,7 @@
 
 <!-- Section bouton -->
 <div class="row">
-    <div class="col-sm-1 col-md-1 col-lg-1 d-flex justify-content-between">
+    <div class="d-flex flex-row-reverse" style="width: 800px">
         <button @onclick=@Post class="boutonExerciceGauche">Éxecuter</button>
         <button @onclick=@Save class="boutonExerciceDroite">Sauvegarder</button>
     </div>


### PR DESCRIPTION
# Description

Déplacement des deux boutons a droite car plus esthétique et intuitif.

Fixes #134 (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
